### PR TITLE
fix(dependabot): update npm patch versions in a batch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,8 @@ updates:
     open-pull-requests-limit: 1
     schedule:
       interval: "weekly"
+    # https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups
+    groups:
+      patch-versions:
+        update-types:
+          - "patch"


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Updating patch versions 1 by 1 like in #25 is inefficient, especially with 1 PR per week limit

Changes introduced in this pull request:

- update npm patch versions in a batch

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

- [x] I have performed a self-review of changes,
- [x] I have checked the website is displayed correctly in browser,
- [x] I have checked the current information reflects the current state of the Forest project,

<!-- Thank you 🔥 -->
