### PR TITLE
fix: update Twitter URL to x.com format  Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -29,7 +29,7 @@ export const navigation = {
     { name: 'Security', href: 'mailto:security@chainsafe.io' }],
   social: [
     {
-      name: 'Twitter',
+      name: 'X',
       href: 'https://x.com/ChainSafeth',
       icon: (props: any) => (
         <svg

--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -30,7 +30,7 @@ export const navigation = {
   social: [
     {
       name: 'Twitter',
-      href: 'https://twitter.com/ChainSafeth',
+      href: 'https://x.com/ChainSafeth',
       icon: (props: any) => (
         <svg
           role='img'


### PR DESCRIPTION
[
](fix: update Twitter URL to x.com format  Replaced the outdated Twitter URL (https://twitter.com) with the updated x.com format (https://x.com) to align with the platform's rebranding.)