### PR TITLE
fix: career link dead, long live join us

### DIFF
--- a/src/components/Footer/index.tsx
+++ b/src/components/Footer/index.tsx
@@ -18,7 +18,7 @@ export const navigation = {
   ],
   resources: [
     { name: 'About ChainSafe', href: 'https://chainsafe.io/' },
-    { name: 'Careers', href: 'https://chainsafe.io/careers' },
+    { name: 'Careers', href: 'https://chainsafe.io/about-us#join-us' },
     {
       name: 'Brand Assets',
       href: '/forest-logo-mini.zip',

--- a/src/sections/Contributors/index.tsx
+++ b/src/sections/Contributors/index.tsx
@@ -24,7 +24,7 @@ export default function Contributors() {
               Join the team!
             </h3>
             <div className='flex gap-x-3 pt-3'>
-              <Button type='primary' href="http://chainsafe.io/careers">Open Positions</Button>
+              <Button type='primary' href="https://chainsafe.io/about-us#join-us">Open Positions</Button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary of changes

<!-- Please write a comprehensive summary of your changes and what was the motivation behind them -->

Changes introduced in this pull request:

- the chainsafe website has been revamped, careers link is no longer there; the closest thing I could find is https://chainsafe.io/about-us#join-us given the single page nature of the website.

## Reference issue to close (if applicable)

<!-- Include the issue reference this pull request is connected to -->
<!-- See more keywords here https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-using-a-keyword -->
<!--(e.g. Closes #1)-->

Closes

## Other information and links

<!-- Add any other context about the pull request here. Those might be helpful links based on your investigation, relevant commits from this or other repositories or anything else -->

## Change checklist

- [x] I have performed a self-review of changes,
- [x] I have checked the website is displayed correctly in browser,
- [x] I have checked the current information reflects the current state of the Forest project,

<!-- Thank you 🔥 -->
